### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,4 +1,6 @@
 name: Test Build Docker Image
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Hack-PSU/emails/security/code-scanning/1](https://github.com/Hack-PSU/emails/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Since the workflow primarily involves checking out the repository and building a Docker image, it only needs `contents: read` permissions. This ensures that the `GITHUB_TOKEN` has minimal access, reducing the risk of misuse.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
